### PR TITLE
ci(security): use takumi guard

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,8 @@ jobs:
       go-version-file: go.mod
       aqua_policy_allow: true
       aqua_version: v2.59.1
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,5 +17,8 @@ jobs:
       - run: exit 1
   test:
     uses: ./.github/workflows/workflow_call_test.yaml
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       contents: read
+      id-token: write

--- a/.github/workflows/wc-test.yaml
+++ b/.github/workflows/wc-test.yaml
@@ -1,11 +1,17 @@
 ---
 name: wc-test
-on: workflow_call
+on:
+  workflow_call:
+    secrets:
+      TAKUMI_GUARD_BOT_ID:
+        required: true
 jobs:
   test:
     timeout-minutes: 30
     runs-on: ubuntu-latest
-    permissions: {}
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -13,6 +19,11 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
+
+      - uses: flatt-security/setup-takumi-guard-golang@2e3c7c40b538cd68b2ac483def12982ebc8bc02e # v1
+        with:
+          bot-id: ${{secrets.TAKUMI_GUARD_BOT_ID}}
+
       - uses: aquaproj/aqua-installer@11dd79b4e498d471a9385aa9fb7f62bb5f52a73c # v4.0.4
         with:
           aqua_version: v2.59.1

--- a/.github/workflows/workflow_call_test.yaml
+++ b/.github/workflows/workflow_call_test.yaml
@@ -1,6 +1,10 @@
 ---
 name: test (workflow_call)
-on: workflow_call
+on:
+  workflow_call:
+    secrets:
+      TAKUMI_GUARD_BOT_ID:
+        required: true
 permissions: {}
 jobs:
   path-filter:
@@ -30,4 +34,8 @@ jobs:
   test:
     uses: ./.github/workflows/wc-test.yaml
     needs: path-filter
-    permissions: {}
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
+    permissions:
+      contents: read
+      id-token: write


### PR DESCRIPTION
Introduce takumi guard into the Go CI workflows.

## Changes

- `.github/workflows/release.yaml`: Added a `secrets:` block passing `TAKUMI_GUARD_BOT_ID` to the `go-release-workflow` reusable workflow call (ref already pinned at v8.1.0).
- `.github/workflows/wc-test.yaml`: Declared the required `TAKUMI_GUARD_BOT_ID` secret under `on.workflow_call.secrets`; added the `flatt-security/setup-takumi-guard-golang@2e3c7c40b538cd68b2ac483def12982ebc8bc02e # v1` setup step immediately after `actions/setup-go` and before `aquaproj/aqua-installer` (which precedes `golangci-lint run`, `go test`, and `go install`); added `id-token: write` and `contents: read` to the `test` job permissions.
- `.github/workflows/workflow_call_test.yaml`: Declared the required `TAKUMI_GUARD_BOT_ID` secret under `on.workflow_call.secrets`; passed it to the `wc-test.yaml` call and added `id-token: write` (plus `contents: read`) to the `test` job.
- `.github/workflows/test.yaml`: Passed `TAKUMI_GUARD_BOT_ID` to the `workflow_call_test.yaml` call from the `pull_request` entrypoint and added `id-token: write` to that calling job.

The `TAKUMI_GUARD_BOT_ID` secret must be configured in the repository/organization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)